### PR TITLE
Use linked-hash-map on Github repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-linked-hash-map = "*"
+linked-hash-map = { git = "https://github.com/contain-rs/linked-hash-map" }


### PR DESCRIPTION
For dev version of `lru-cache`, it could use the dev version of `linked-hash-map`.
