### PR TITLE
Replace deprecated `HashState` with `BuildHasher`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-linked-hash-map = "*"
+linked-hash-map = "0.0.8"


### PR DESCRIPTION
Also fixed #20 . Depend on linked-hash-map of v0.0.8
