### PR TITLE
Update linked-hash-map to the new 0.1.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-linked-hash-map = "0.0.9"
+linked-hash-map = "0.1.0"


### PR DESCRIPTION
When playing with this I noticed that the code was downloading and compiling an old version of linked-hash-map. I ran the unit tests with the new version and everything appeared to be all right. 
