### PR TITLE
Implement `at_max_capacity`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ impl<K: Eq + Hash, V> LruCache<K, V> {
     /// let mut cache: LruCache<i32, &str> = LruCache::at_max_capacity(10);
     /// assert!(cache.capacity() >= 10);
     /// ```
-    pub fn at_max_capacity(max_size: usize) -> LruCache<K, V> {
+    pub fn at_max_capacity(max_size: usize) -> Self {
         LruCache {
             map: LinkedHashMap::with_capacity(max_size),
             max_size: max_size,


### PR DESCRIPTION
Issue: https://github.com/contain-rs/lru-cache/issues/9

I think it makes more sense to have either not initialize the underlying map or initialize the map at max capacity. Let me know what you think. I also updated the various references to the cache `capacity` to `max_size` as not to confuse `capacity` as allocated space with `capacity` as number of elements in the cache. 
