### PR TITLE
Update the linked-hash-map dependency to use the new 0.2.1 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["data-structures"]
 readme = "README.md"
 
 [dependencies]
-linked-hash-map = "0.1.0"
+linked-hash-map = "^0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
 impl<K, V, S> LruCache<K, V, S> where K: Eq + Hash, S: BuildHasher {
     /// Creates an empty cache that can hold at most `capacity` items with the given hash state.
     pub fn with_hasher(capacity: usize, hash_state: S) -> LruCache<K, V, S> {
-        LruCache { map: LinkedHashMap::with_hash_state(hash_state), max_size: capacity }
+        LruCache { map: LinkedHashMap::with_hasher(hash_state), max_size: capacity }
     }
 
     /// Checks if the map contains the given key.


### PR DESCRIPTION
Man, a lot of new goodness from the linked-hash-map library. 
