### PR TITLE
Allow arbitrary measures for cache size limit. Fixes #38.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ documentation = "https://contain-rs.github.io/lru-cache/lru_cache"
 keywords = ["data-structures"]
 readme = "README.md"
 
+[features]
+default = []
+
 [dependencies]
 linked-hash-map = "0.2"
+heapsize = { version = "0.3.7", optional = true }


### PR DESCRIPTION
This commit allows creating LruCaches that are limited in size by
something other than a count of entries. It does this by providing a
new trait, `Meter`, where implementations of the trait provide a
`measure` method to do the measurement. The default behavior of
measuring by the count of entries is provided by a `Count` type.

Due to difficulties with mutating entries making it possible to change
an item's measure, the `get_mut` and `iter_mut` methods are provided
only on LruCaches using `Count` for sizing.

A bit of optimization is provided for the default case--to avoid having
to redundantly store the item count the `Meter` trait allows implementations
to provide a type for storing the measurement, and the `Count` implementation
uses `()`. The `CountableMeter` trait allows `LruCache` to work with this
or any `Meter` implementation that uses `usize` for measurement.

Finally an optional feature is added, `heapsize`, which uses the heapsize
crate to provide HeapSizeOf, a measurement based on the heap memory usage
of values stored in the cache.

Thanks to @rphmeier for the design suggestions!

Since this makes `get_mut` not available on caches that aren't using the default `Count` metric, you will probably want to get [non-mutable get](https://github.com/contain-rs/lru-cache/pull/37) merged as well to mitigate that.

One issue that's not addressed by this change is providing the list of removed items on an `insert` or `set_capacity` that requires removing multiple items. This would make my use case simpler, so I may implement that as a follow-up once this PR is finished.