### PR TITLE
Some changes to work better without mutability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,11 +90,11 @@ impl<K: Eq + Hash, V, S: BuildHasher> LruCache<K, V, S> {
     /// cache.insert(1, "a");
     /// assert_eq!(cache.contains_key(&1), true);
     /// ```
-    pub fn contains_key<Q: ?Sized>(&mut self, key: &Q) -> bool
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
         where K: Borrow<Q>,
               Q: Hash + Eq
     {
-        self.get_mut(key).is_some()
+        self.map.contains_key(key)
     }
 
     /// Inserts a key-value pair into the cache. If the key already existed, the old value is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,18 +23,18 @@
 //! cache.insert(1, 10);
 //! cache.insert(2, 20);
 //! cache.insert(3, 30);
-//! assert!(cache.get_mut(&1).is_none());
-//! assert_eq!(*cache.get_mut(&2).unwrap(), 20);
-//! assert_eq!(*cache.get_mut(&3).unwrap(), 30);
+//! assert!(cache.get(&1).is_none());
+//! assert_eq!(*cache.get(&2).unwrap(), 20);
+//! assert_eq!(*cache.get(&3).unwrap(), 30);
 //!
 //! cache.insert(2, 22);
-//! assert_eq!(*cache.get_mut(&2).unwrap(), 22);
+//! assert_eq!(*cache.get(&2).unwrap(), 22);
 //!
 //! cache.insert(6, 60);
-//! assert!(cache.get_mut(&3).is_none());
+//! assert!(cache.get(&3).is_none());
 //!
 //! cache.set_capacity(1);
-//! assert!(cache.get_mut(&2).is_none());
+//! assert!(cache.get(&2).is_none());
 //! ```
 
 extern crate linked_hash_map;
@@ -118,6 +118,31 @@ impl<K: Eq + Hash, V, S: BuildHasher> LruCache<K, V, S> {
             self.remove_lru();
         }
         old_val
+    }
+
+    /// Returns a reference to the value corresponding to the given key in the cache, if
+    /// any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lru_cache::LruCache;
+    ///
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.insert(1, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(2, "c");
+    /// cache.insert(3, "d");
+    ///
+    /// assert_eq!(cache.get(&1), None);
+    /// assert_eq!(cache.get(&2), Some(&"c"));
+    /// ```
+    pub fn get<Q: ?Sized>(&mut self, k: &Q) -> Option<&V>
+        where K: Borrow<Q>,
+              Q: Hash + Eq
+    {
+        self.map.get_refresh(k).map(|v| v as &V)
     }
 
     /// Returns a mutable reference to the value corresponding to the given key in the cache, if
@@ -438,6 +463,8 @@ mod tests {
         let mut cache = LruCache::new(2);
         cache.insert(1, 10);
         cache.insert(2, 20);
+        assert_eq!(cache.get(&1), Some(&10));
+        assert_eq!(cache.get(&2), Some(&20));
         assert_eq!(cache.get_mut(&1), Some(&mut 10));
         assert_eq!(cache.get_mut(&2), Some(&mut 20));
         assert_eq!(cache.len(), 2);


### PR DESCRIPTION
I built something atop my changes in https://github.com/contain-rs/lru-cache/pull/40 and I wound up needing a pair of small additional changes:
* First, I needed a `get` method that returned a non-mutable reference, since my changes in that PR make `get_mut` available only when using the default `Count` metric, so when using a different metric there's no way to actually get items from the cache. This differs from [the immutable get](https://github.com/contain-rs/lru-cache/pull/37) PR in that it still updates the LRU state of the cache, it just returns a non-mutable reference to the cache entry.
* Second, I wanted to use `contains_key` without having a mutable reference to the cache, which is pretty simple (maybe the underlying `LinkedHashMap` didn't implement `contains_key` when this code was originally written?)
