### PR TITLE
Update to linked-hash-map 0.5 and heapsize 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ readme = "README.md"
 heapsize_impl = ["heapsize", "linked-hash-map/heapsize_impl"]
 
 [dependencies]
-linked-hash-map = "0.4.2"
+linked-hash-map = "0.5"
 
-heapsize = { version = "0.3.9", optional = true }
+heapsize = { version = "0.4", optional = true }


### PR DESCRIPTION
Please publish new version to crates.io