### PR TITLE
make contains_key() read-only

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> LruCache<K, V, S> {
         LruCache { map: LinkedHashMap::with_hasher(hash_builder), max_size: capacity }
     }
 
-    /// Checks if the map contains the given key.
+    /// Checks if the map contains the given key. Read-only operation, does not update LRU state.
     ///
     /// # Examples
     ///
@@ -93,11 +93,11 @@ impl<K: Eq + Hash, V, S: BuildHasher> LruCache<K, V, S> {
     /// cache.insert(1, "a");
     /// assert_eq!(cache.contains_key(&1), true);
     /// ```
-    pub fn contains_key<Q: ?Sized>(&mut self, key: &Q) -> bool
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
         where K: Borrow<Q>,
               Q: Hash + Eq
     {
-        self.get_mut(key).is_some()
+        self.map.contains_key(key)
     }
 
     /// Inserts a key-value pair into the cache. If the key already existed, the old value is


### PR DESCRIPTION
My expectation was that `contains_key()` would be read-only, not update the LRU state, and therefore not also require an exclusive lock to use.

If a user of the library wants to do the equivalent of `contains_key()` and update the LRU state, they can always do `cache.get_mut(key).is_some()`, which is pretty trivial code. On the other hand, without this change, there is no way to do a read-only `contains_key()`.