### PR TITLE
deps: constrain linked-hash-map to >=0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ exclude = ["/.travis.yml", "/deploy-docs.sh"]
 heapsize_impl = ["heapsize", "linked-hash-map/heapsize_impl"]
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 
 heapsize = { version = "0.4", optional = true }


### PR DESCRIPTION
Fixes uninitialized panic issue found in earlier versions.

Fixes #50